### PR TITLE
Get queueName and priorityClass directly from [Workload].spec in plots.py

### DIFF
--- a/kblaunch/plots.py
+++ b/kblaunch/plots.py
@@ -484,12 +484,8 @@ def get_queue_data(namespace: str, include_cpu: bool = False) -> pd.DataFrame:
                 user = wl["spec"]["podSets"][0]["template"]["metadata"]["labels"].get(
                     "eidf/user", "unknown"
                 )
-                queue = wl["spec"]["podSets"][0]["template"]["metadata"]["labels"].get(
-                    "kueue.x-k8s.io/queue-name", "unknown"
-                )
-                priority = wl["spec"]["podSets"][0]["template"]["metadata"][
-                    "labels"
-                ].get("kueue.x-k8s.io/priority-class", "default-workload-priority")
+                queue = wl["spec"].get("queueName", "unknown") # this should actually trigger an error - UG
+                priority = wl["spec"].get("priorityClassName", "unknown") #  this too
             except KeyError:
                 user = "labels-missing"
                 queue = "labels-missing"


### PR DESCRIPTION
The priority class can be set either in [Job].metadata.labels or [Pod/[Job].spec.template].metadata.labels. The prior version of plots.py always assumed that it was the latter and listed the wrong priority class if it was specified in [Job].metadata.labels (which is the "official" place for doing so.)